### PR TITLE
docs(map): example syntax error

### DIFF
--- a/docs/examples/map/custom-bubble-symbols/main.tsx
+++ b/docs/examples/map/custom-bubble-symbols/main.tsx
@@ -73,7 +73,7 @@ const App = () => {
             </MapLayers>
         </Map>
     );
-);
+};
 
 ReactDOM.render(
     <App />,


### PR DESCRIPTION
Fix an oopsie!