### PR TITLE
chore: set package prefix to @progress

### DIFF
--- a/docs/auto-imports.js
+++ b/docs/auto-imports.js
@@ -82,13 +82,13 @@ window.moduleDirectives = (window.moduleDirectives || []).concat(
             main: 'dist/cdn/main.js',
         },
         {
-            module: '@telerik/kendo-intl',
+            module: '@progress/kendo-intl',
             main: 'dist/cdn/main.js',
         },
         {
             module: 'ical.js',
             main: 'build/ical.js',
         }
-        
+
     ]
 );

--- a/docs/examples/scheduler/export-to-ical/main.jsx
+++ b/docs/examples/scheduler/export-to-ical/main.jsx
@@ -14,7 +14,7 @@ import { ZonedDate } from "@progress/kendo-date-math";
 import "@progress/kendo-date-math/tz/America/New_York";
 import "@progress/kendo-date-math/tz/America/Los_Angeles";
 
-import { formatDate } from "@telerik/kendo-intl";
+import { formatDate } from "@progress/kendo-intl";
 
 import { saveAs } from "@progress/kendo-file-saver";
 


### PR DESCRIPTION
Update `kendo-intl` to the new `@progress` scope.